### PR TITLE
Update and extend unit tests for PdfBox 1.8.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,9 @@ A PHP interface for the [PdfBox ExtractText](http://pdfbox.apache.org/commandlin
 
 ## Requirements
 - Java Runtime Environment
-- Pdfbox jar file. Download from here: http://pdfbox.apache.org/downloads.html
-  Tested with 1.6.0 and 1.7.0
+- PdfBox JAR file
+  - Download: http://pdfbox.apache.org/downloads.html
+  - Tested with 1.6.0, 1.7.0 and 1.8.6
 - PHP needs permissions for shell execution
 
 ## Basic Usage
@@ -46,4 +47,4 @@ $converter->getOptions()
 ```
 
 ## PHPUnit tests
-To run the unit tests, change the environment variable `pdfbox-jar` to the full path of your PdfBox jar file. See *phpunit.xml.dist*
+To run the unit tests, change the environment variable `PDFBOX_JAR` to the full path of your PdfBox JAR file. See *phpunit.xml.dist*.

--- a/composer.json
+++ b/composer.json
@@ -13,6 +13,9 @@
     "require": {
         "php": ">=5.3.0"
     },
+    "require-dev": {
+        "phpunit/phpunit-dom-assertions": "1.0.*@dev"
+    },
     "autoload": {
         "psr-0": {
             "SGH\\PdfBox": "src/"

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -6,6 +6,6 @@
         </testsuite>
     </testsuites>
     <php>
-        <env name="pdfbox-jar" value="pdfbox-app-1.8.6.jar" />
+        <env name="PDFBOX_JAR" value="pdfbox-app-1.8.6.jar" />
     </php>
 </phpunit>

--- a/test/SGH/PdfBox/CommandTest.php
+++ b/test/SGH/PdfBox/CommandTest.php
@@ -13,7 +13,10 @@ namespace SGH\PdfBox;
  */
 class CommandTest extends \PHPUnit_Framework_TestCase
 {
-    private $jar = 'pdfbox-app-1.6.0.jar';
+    /**
+     * @var string
+     */
+    private $jar;
 
     /**
      * @var Command
@@ -26,11 +29,16 @@ class CommandTest extends \PHPUnit_Framework_TestCase
     protected function setUp()
     {
         parent::setUp();
-        $this->jar = getenv('pdfbox-jar') ?: $this->jar;
-        $this->Command = new Command(/* parameters */);
-        $this->Command->setPdfFile('in.pdf');
-        $this->Command->setTextFile('out.txt');
-        $this->Command->setJar($this->jar);
+
+        $this->jar = getenv('PDFBOX_JAR');
+        if ($this->jar !== false) {
+            $this->Command = new Command();
+            $this->Command->setPdfFile('in.pdf');
+            $this->Command->setTextFile('out.txt');
+            $this->Command->setJar($this->jar);
+        } else {
+            $this->markTestSkipped('PDFBOX_JAR is not set.');
+        }
     }
 
     /**
@@ -48,7 +56,7 @@ class CommandTest extends \PHPUnit_Framework_TestCase
     public function testDefault()
     {
         $cmd = $this->Command->__toString();
-        $this->assertEquals("java -jar \"{$this->jar}\" ExtractText -encoding UTF-8 \"in.pdf\" \"out.txt\"", $cmd);
+        $this->assertEquals("java -jar '{$this->jar}' ExtractText -encoding UTF-8 'in.pdf' 'out.txt'", $cmd);
     }
 
     public function testHtmlToConsole()
@@ -56,7 +64,7 @@ class CommandTest extends \PHPUnit_Framework_TestCase
         $this->Command->setAsHtml(true);
         $this->Command->setToConsole(true);
         $cmd = $this->Command->__toString();
-        $this->assertEquals("java -jar \"{$this->jar}\" ExtractText -encoding UTF-8 -html -console \"in.pdf\" \"out.txt\"", $cmd);
+        $this->assertEquals("java -jar '{$this->jar}' ExtractText -encoding UTF-8 -html -console 'in.pdf' 'out.txt'", $cmd);
     }
 
     public function testSomeOptions()
@@ -67,14 +75,13 @@ class CommandTest extends \PHPUnit_Framework_TestCase
             ->setStartPage(2)
             ->setEndPage(10);
         $cmd = $this->Command->__toString();
-        $this->assertEquals("java -jar \"{$this->jar}\" ExtractText -encoding UTF-8 -html -force -startPage 2 -endPage 10 \"in.pdf\" \"out.txt\"", $cmd);
+        $this->assertEquals("java -jar '{$this->jar}' ExtractText -encoding UTF-8 -html -force -startPage 2 -endPage 10 'in.pdf' 'out.txt'", $cmd);
     }
 
     public function testPath()
     {
         $this->Command->setJar('/path/to/pdfbox.jar');
         $cmd = $this->Command->__toString();
-        $this->assertEquals("java -jar \"/path/to/pdfbox.jar\" ExtractText -encoding UTF-8 \"in.pdf\" \"out.txt\"", $cmd);
+        $this->assertEquals("java -jar '/path/to/pdfbox.jar' ExtractText -encoding UTF-8 'in.pdf' 'out.txt'", $cmd);
     }
 }
-


### PR DESCRIPTION
The current version of PdfBox (1.8.6) now passes all unit tests. In addition `domFromPdfX` are now being tested.
Older releases (such as 1.6.0 and 1.7.1) do not pass all test cases as newer versions are able to detect bold text. The interface itself does work as intended tough.

In addition I changed `pdfbox-jar` to `PDFBOX_JAR`: This way you can invoke `PDFBOX_JAR=yourpdfbox.jar phpunit -v` which eases the unit testing with different versions of PdfBox.
